### PR TITLE
Fixed issue #18 during installation

### DIFF
--- a/profiles/cod/cod.info
+++ b/profiles/cod/cod.info
@@ -103,9 +103,6 @@ dependencies[] = cod_profile_base
 dependencies[] = cod_wysiwyg
 files[] = cod.profile
 
-; AED Customizations
-dependencies[] = aedcamp
-
 ; System Requirements.
 php_memory_limit = 128M
 

--- a/profiles/cod/modules/custom/aedcamp/aedcamp.info
+++ b/profiles/cod/modules/custom/aedcamp/aedcamp.info
@@ -3,3 +3,15 @@ description = AED Customizations to COD for spanish drupalcamps.
 core = 7.x
 version = 7.x-1.0
 package = AED
+
+dependencies[] = cod_paid_events
+dependencies[] = commerce
+dependencies[] = commerce_cart
+dependencies[] = commerce_checkout
+dependencies[] = commerce_customer
+dependencies[] = commerce_line_item
+dependencies[] = commerce_order
+dependencies[] = commerce_payment
+dependencies[] = commerce_paypal
+dependencies[] = commerce_price
+dependencies[] = commerce_product

--- a/profiles/cod/modules/custom/aedcamp/aedcamp.install
+++ b/profiles/cod/modules/custom/aedcamp/aedcamp.install
@@ -9,7 +9,7 @@
  * Implements hook_install().
  */
 function aedcamp_install() {
-  $updates = array(7001, 7002, 7003);
+  $updates = array(7003);
   foreach ($updates as $update) {
     call_user_func('aedcamp_update_' . $update);
   }
@@ -73,3 +73,4 @@ function aedcamp_update_7003() {
   $node->uid = 1;
   node_save($node);
 }
+


### PR DESCRIPTION
This should fix the error during the installation, but adds an extra step to do after installing the profile. It's necessary to install aedcamp module manually. This is caused by the cod_paid_event module. I don't know why it breaks the installation.