### PR TITLE
#194 Attendees View

### DIFF
--- a/profiles/cod/modules/contrib/ticket/ticket.module
+++ b/profiles/cod/modules/contrib/ticket/ticket.module
@@ -216,7 +216,15 @@ function ticket_type_load($ttid) {
 function ticket_type_label($ticket_type, $entity_type = 'ticket_type') {
   // TODO: Not sure where this is getting called with the wrong args.
   if (!is_object($ticket_type) || get_class($ticket_type) != 'TicketTypeEntity') {
-    return;
+    if (isset($ticket_type->ttid)) {
+      $ticket_type = entity_load_single('ticket_type', $ticket_type->ttid);
+      if (!is_object($ticket_type) || get_class($ticket_type) != 'TicketTypeEntity') {
+        return;
+      }
+    }
+    else {
+      return;
+    }
   }
 
   $host = $ticket_type->host();
@@ -728,6 +736,9 @@ function ticket_registration_get_properties($entity, array $options, $name, $typ
 
     case 'author':
       return $entity->registrant();
+
+    case 'label':
+      return $entity->label();
 
   }
 }

--- a/profiles/cod/modules/features/aed_collaborators/aed_collaborators.module
+++ b/profiles/cod/modules/features/aed_collaborators/aed_collaborators.module
@@ -13,6 +13,7 @@ include_once 'aed_collaborators.features.inc';
  */
 function aed_collaborators_views_query_alter(&$view, &$query) {
   if ($view->name === 'aed_attendees') {
+    // Show the user that will use the ticket, not the buyer.
     $view->query->table_queue['ticket_registration_users']['join']->field = 'user_uid';
 
     if ($view->current_display === 'bd') {

--- a/profiles/cod/modules/features/aed_collaborators/aed_collaborators.views_default.inc
+++ b/profiles/cod/modules/features/aed_collaborators/aed_collaborators.views_default.inc
@@ -61,6 +61,11 @@ function aed_collaborators_views_default_views() {
   $handler->display->display_options['relationships']['ticket_registration']['id'] = 'ticket_registration';
   $handler->display->display_options['relationships']['ticket_registration']['table'] = 'users';
   $handler->display->display_options['relationships']['ticket_registration']['field'] = 'ticket_registration';
+  $handler->display->display_options['relationships']['ticket_registration']['bundle_types'] = array(
+    10 => '10',
+    11 => '11',
+    13 => '13',
+  );
   /* Campo: Usuario: Imagen */
   $handler->display->display_options['fields']['picture']['id'] = 'picture';
   $handler->display->display_options['fields']['picture']['table'] = 'users';
@@ -103,6 +108,11 @@ function aed_collaborators_views_default_views() {
   $handler->display->display_options['filters']['uid_raw']['field'] = 'uid_raw';
   $handler->display->display_options['filters']['uid_raw']['operator'] = '!=';
   $handler->display->display_options['filters']['uid_raw']['value']['value'] = '1';
+  /* Filter criterion: Field: Nombre (field_profile_first) */
+  $handler->display->display_options['filters']['field_profile_first_value']['id'] = 'field_profile_first_value';
+  $handler->display->display_options['filters']['field_profile_first_value']['table'] = 'field_data_field_profile_first';
+  $handler->display->display_options['filters']['field_profile_first_value']['field'] = 'field_profile_first_value';
+  $handler->display->display_options['filters']['field_profile_first_value']['operator'] = 'not empty';
 
   /* Display: Attenders */
   $handler = $view->new_display('page', 'Attenders', 'page');


### PR DESCRIPTION
The Attendee view was showing that there were not ticket available. This was the default message for the empty view. The view was empty because all the ticket registrations are marked as "pending" (see ticket_registration/manage/10/registrations) Last year we had to review with paypal and change the status to completes, and I'm afraid that this will be the case again this year. Please, take into account that we need to do the same for individual sponsors, business day attendees and Alhambra visitors.

Additionally, the attendees view uses a relationship with the ticket registration entity, but the view didn't allow us to select the ticket type. This is caused because the view couldn't get the labels of the options, then it always raised an error. This is fixed in this pull request with a change on the ticket module, inside the cod distribution. Maybe we should create a patch for this, but maybe if we update COD this doesn't happen anymore.

Now we don't need to add the ticket bundles by code, so that's removed from the code.

Please take into account that the feature related needs to be reverted.

Next steps:
  * Adapt the styling.
  * Maybe to create additional displays, to show the business day attendees, or automatize the individual sponsors. Do we want to show who is going to visit La Alhambra?
  * Add the menu items.
